### PR TITLE
[tcp-api-server] Fix race condition in graceful server shutdown

### DIFF
--- a/tcp-api-server/Cargo.lock
+++ b/tcp-api-server/Cargo.lock
@@ -2037,7 +2037,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
- "tokio-util",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2199,19 +2198,6 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]

--- a/tcp-api-server/Cargo.toml
+++ b/tcp-api-server/Cargo.toml
@@ -48,7 +48,6 @@ tracing = "0.1.40"
 tracing-appender = "0.2.3"
 tracing-subscriber = "0.3.18"
 tokio = { version = "1.37.0", features = ["full", "tracing"] }
-tokio-util = "0.7.10"                                          # For `CancellationToken`.
 tokio-test = "0.4.4"                                           # For mock `TcpStream` (`Builder`)
 
 [dev-dependencies]

--- a/tcp-api-server/src/main.rs
+++ b/tcp-api-server/src/main.rs
@@ -101,7 +101,7 @@ async fn main() -> miette::Result<()> {
 
             setup_default_miette_global_report_handler(ERROR_REPORT_HANDLER_FOOTER);
 
-            tcp_api_server::server_task::server_main(cli_args).await?
+            tcp_api_server::server_task::server_main_event_loop(cli_args).await?
         }
         // Start client (interactive and needs TerminalAsync). Async writer for stdout.
         tcp_api_server::CLISubcommand::Client => {


### PR DESCRIPTION
Use tokio::sync::broadcast::channel for shutting down the server, to cooperatively & gracefully end all awaiting running tasks. Use this in favor of:
1. `abort()` - behavior is undefined / inconsistent.
2. Dropping the task is not reliable.
3. `CancellationToken` from `tokio_util` crate - does not work the way that broadcast channel or other channels do. It doesn't block when `is_cancelled()` is called, and creates a strange behavior in `tokio::select!` blocks, causing the loop to be run repeatedly. More info: <https://cybernetist.com/2024/04/19/rust-tokio-task-cancellation-patterns/>
